### PR TITLE
Send back status http 404 when item is not found in remote.

### DIFF
--- a/groupcache.go
+++ b/groupcache.go
@@ -34,8 +34,6 @@ import (
 	pb "github.com/runtimeinc/groupcache/groupcachepb"
 	"github.com/runtimeinc/groupcache/lru"
 	"github.com/runtimeinc/groupcache/singleflight"
-	// TESTING
-	"github.com/runtimeinc/clusterkit/slog"
 )
 
 var (
@@ -289,7 +287,6 @@ func (g *Group) load(ctx Context, allowPeer bool, key string, dest Sink) (value 
 
 				// If item is not found, then don't do local lookup
 				if err == ErrItemNotFound {
-					slog.Infof("GROUPCACHE item not found %s", key)
 					g.Stats.PeerErrors.Add(1)
 					return nil, err
 				}


### PR DESCRIPTION
Do not load from local remote error is a 404
Define groupcache.ErrItemNotFound. client code cache filler code should use this return code
and cache lookup code should check for groupcahe.ErrItemNotFound and return status.ErrDeviceNo
(or whatever status.Err it was sending before).